### PR TITLE
Урок 42: Terraform_3

### DIFF
--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -1,0 +1,56 @@
+resource "aws_instance" "frontend" {
+    ami = data.aws_ami.latest_ubuntu.id
+    instance_type = var.instance_type
+    tags = { Name = "frontend1" }
+    vpc_security_group_ids = [aws_security_group.frontend_security_group.id]
+}
+
+resource "aws_instance" "backend" {
+    ami = data.aws_ami.latest_ubuntu.id
+    instance_type = var.instance_type
+    count = 2
+    tags = { Name = "backend${count.index}" }
+    vpc_security_group_ids = [aws_security_group.backend_security_group.id]
+}
+
+resource "aws_security_group" "frontend_security_group" {
+  name = "Frontend Security Group"
+  description = "Open SSH, HTTP, HTTPS port"
+
+    dynamic "ingress" {
+    for_each = var.frontend_ports
+    content {
+        from_port = ingress.value
+        to_port = ingress.value
+        protocol = "tcp"
+        cidr_blocks = [ "0.0.0.0/0" ]
+    }
+    }
+    egress {
+        from_port = 0
+        to_port = 0
+        protocol = "-1"
+        cidr_blocks = [ "0.0.0.0/0" ]    
+    }
+}
+
+resource "aws_security_group" "backend_security_group" {
+  name = "Backend Security Group"
+  description = "Open SSH, Java port"
+    depends_on = [ aws_security_group.frontend_security_group ]
+    dynamic "ingress" {
+    for_each = var.backend_ports
+    content {
+        from_port = ingress.value
+        to_port = ingress.value
+        protocol = "tcp"
+        security_groups = [aws_security_group.frontend_security_group.id]
+    }
+    }
+    egress {
+        from_port = 0
+        to_port = 0
+        protocol = "-1"
+        cidr_blocks = [ "0.0.0.0/0" ]    
+    }
+}

--- a/Terraform/outputs.tf
+++ b/Terraform/outputs.tf
@@ -1,0 +1,12 @@
+data "aws_ami" "latest_ubuntu" {
+    owners = ["099720109477"]
+    most_recent = true
+    filter {
+      name = "name"
+      values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+    }
+}
+
+output "latest_ubuntu_ami_id" {
+  value = data.aws_ami.latest_ubuntu.id
+}

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -1,0 +1,14 @@
+variable "instance_type" {
+    type = string
+    default = "t2.micro"
+}
+
+variable "frontend_ports" {
+    type = list
+    default = ["22", "80", "443"]
+}
+
+variable "backend_ports" {
+    type = list
+    default = ["22", "8080"]
+}


### PR DESCRIPTION
ДЗ:
создать в тераформе инфраструктуру на базе 2 сг (фронт и бэк) и 3 инстансов (1 фронт и 2 бэка). Фронт сг должна разрешать доступ по 22, 80 и 443 портам для всего мира, бэк сг по 22 и 8080 портам для сг фронта. Желательно делать сразу разбиение компонентов (переменные, выводы, провайдер и ресурсы) на отдельные файлы и использовать минимум хардкода в описании ресурсов, таких как инстансы. Будет плюсом настроить мапинг ами ид для инстансов